### PR TITLE
Resolve references

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,10 +1,15 @@
-enum Events {
+import { contains } from './strings'
+import { settings } from './settings'
+
+const Settings = settings();
+
+export enum Events {
   Register,
   Cancel,
   Contact
 }
 
-namespace Events {
+export namespace Events {
   export function suffix(event: Events): string {
     switch (event) {
       case Events.Register:
@@ -68,7 +73,7 @@ namespace Events {
 
 }
 
-function matchedEvent(subject: string): Events {
+export function matchedEvent(subject: string): Events {
   var all = Events.all();
   var e;
   all.forEach(function (event) {
@@ -79,7 +84,7 @@ function matchedEvent(subject: string): Events {
   return e;
 }
 
-function expectedEvent(subject: string): boolean {
+export function expectedEvent(subject: string): boolean {
   var all = Events.all();
   var result = false;
   all.forEach(function (event) {

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -5,13 +5,13 @@
 </a>'
 */
 
-function extractUserName(messageHTMLBody: string) {
+export function extractUserName(messageHTMLBody: string) {
   let pattern = '<strong>(.+?)</strong>';
   let regex = new RegExp(pattern);
   return messageHTMLBody.match(regex)[1]
 }
 
-function extractUserNameLink(messageHTMLBody: string) {
+export function extractUserNameLink(messageHTMLBody: string) {
   let pattern = 'https://connpass.com/user/.+?/'
   let regex = new RegExp(pattern);
   return messageHTMLBody.match(regex)[0]
@@ -20,13 +20,13 @@ function extractUserNameLink(messageHTMLBody: string) {
 /*
   <a href="mailto:example@example.example">example-example &lt;example@example.example&gt;</a></span></td>
 */
-function extractContactSourceName(messageHTMLBody: string) {
+export function extractContactSourceName(messageHTMLBody: string) {
   let pattern = '<a href=".+">.+ &lt;(.+?)&gt;</a></span></td>'
   let regex = new RegExp(pattern);
   return messageHTMLBody.match(regex)[1]
 }
 
-function extractContactSourceAddress(messageHTMLBody: string) {
+export function extractContactSourceAddress(messageHTMLBody: string) {
   let pattern = '<a href="mailto:(.+?)">'
   let regex = new RegExp(pattern);
   return messageHTMLBody.match(regex)[1]

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,7 @@
+import { settings } from './settings'
+import { Events, matchedEvent, expectedEvent } from './events'
+import { buildFields } from './parameters'
+
 const Settings = settings();
 
 var max: number = null;

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -1,3 +1,11 @@
+import { Events } from './events' 
+import {
+  extractContactSourceAddress,
+  extractContactSourceName,
+  extractUserNameLink,
+  extractUserName
+} from './extractor'
+
 function isContact(event: Events) {
   return event == Events.Contact;
 }
@@ -6,7 +14,7 @@ function isRegisterOrCancel(event: Events) {
   return event == Events.Register || event == Events.Cancel;
 }
 
-function buildFields(event: Events, messageHTMLBody: string) {
+export function buildFields(event: Events, messageHTMLBody: string) {
   if (isContact(event)) {
     return [
       {

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -1,10 +1,5 @@
 import { Events } from './events' 
-import {
-  extractContactSourceAddress,
-  extractContactSourceName,
-  extractUserNameLink,
-  extractUserName
-} from './extractor'
+import { extractContactSourceAddress, extractContactSourceName, extractUserNameLink, extractUserName } from './extractor'
 
 function isContact(event: Events) {
   return event == Events.Contact;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,7 +9,7 @@ interface _Settings {
   contactNotificationChannel: string
 }
 
-function settings(): _Settings {
+export function settings(): _Settings {
   return {
     'appName': 'Gmail',
     'searchWord': 'from: no-reply@connpass.com',

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -1,3 +1,3 @@
-function contains(content: string, word: string) {
+export function contains(content: string, word: string) {
   return content.indexOf(word) > 0
 }


### PR DESCRIPTION
fix #4 

## サマリ

- importとexport文を追加しました．
- 04e6ff4 で の修正は `ts2gas` という `clasp` が依存するモジュールの不具合に対応するものです．`ts2gas` にもPR送るので，それがマージされた際に元に戻します．

## 確認項目

- [x] 私のSlackチームでテストして無事動くことを確認しました
- [x] VisualStudio Codeでエラーが表示されなくなることを確認しました