### PR TITLE
変数宣言部を一部 `let` から `const` に置き換え

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -74,8 +74,8 @@ export namespace Events {
 }
 
 export function matchedEvent(subject: string): Events {
-  var all = Events.all();
-  var e;
+  const all = Events.all();
+  let e;
   all.forEach(function (event) {
     if (contains(subject, Events.suffix(event))) {
       e = event;
@@ -85,8 +85,8 @@ export function matchedEvent(subject: string): Events {
 }
 
 export function expectedEvent(subject: string): boolean {
-  var all = Events.all();
-  var result = false;
+  const all = Events.all();
+  let result = false;
   all.forEach(function (event) {
     result = result || contains(subject, Events.suffix(event));
   });

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -6,14 +6,14 @@
 */
 
 export function extractUserName(messageHTMLBody: string) {
-  let pattern = '<strong>(.+?)</strong>';
-  let regex = new RegExp(pattern);
+  const pattern = '<strong>(.+?)</strong>';
+  const regex = new RegExp(pattern);
   return messageHTMLBody.match(regex)[1]
 }
 
 export function extractUserNameLink(messageHTMLBody: string) {
-  let pattern = 'https://connpass.com/user/.+?/'
-  let regex = new RegExp(pattern);
+  const pattern = 'https://connpass.com/user/.+?/'
+  const regex = new RegExp(pattern);
   return messageHTMLBody.match(regex)[0]
 }
 
@@ -21,13 +21,13 @@ export function extractUserNameLink(messageHTMLBody: string) {
   <a href="mailto:example@example.example">example-example &lt;example@example.example&gt;</a></span></td>
 */
 export function extractContactSourceName(messageHTMLBody: string) {
-  let pattern = '<a href=".+">.+ &lt;(.+?)&gt;</a></span></td>'
-  let regex = new RegExp(pattern);
+  const pattern = '<a href=".+">.+ &lt;(.+?)&gt;</a></span></td>'
+  const regex = new RegExp(pattern);
   return messageHTMLBody.match(regex)[1]
 }
 
 export function extractContactSourceAddress(messageHTMLBody: string) {
-  let pattern = '<a href="mailto:(.+?)">'
-  let regex = new RegExp(pattern);
+  const pattern = '<a href="mailto:(.+?)">'
+  const regex = new RegExp(pattern);
   return messageHTMLBody.match(regex)[1]
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,14 +11,14 @@ function dryRun() {
 }
 
 function main() {
-  let threads = GmailApp.search(Settings.searchWord);
+  const threads = GmailApp.search(Settings.searchWord);
   let count = threads.length;
   if (max != null && count != 0) {
     count = max;
   }
 
   for (let i = 0; i < count; i++) {
-    let thread = threads[i];
+    const thread = threads[i];
     if (!thread.isUnread()) {
       // While already read mail.
       break;
@@ -29,17 +29,17 @@ function main() {
 }
 
 function sendIfExpected(thread: GoogleAppsScript.Gmail.GmailThread) {
-  let subject = thread.getFirstMessageSubject();
+  const subject = thread.getFirstMessageSubject();
   if (!expectedEvent(subject)) {
     console.log(Utilities.formatString("Unexpected mail subject, got %s", subject));
     return;
   }
-  let event = matchedEvent(subject);
-  let messageHTMLBody = thread.getMessages()[0].getBody();
-  let permanentLink = thread.getPermalink();
-  let timestamp = thread.getLastMessageDate().getTime() / 1000;
+  const event = matchedEvent(subject);
+  const messageHTMLBody = thread.getMessages()[0].getBody();
+  const permanentLink = thread.getPermalink();
+  const timestamp = thread.getLastMessageDate().getTime() / 1000;
 
-  let jsonPayload = {
+  const jsonPayload = {
     "fallback": "Notfify connpass events from gmail",
     "channel": Events.channel(event),
     "username": Settings.appName,
@@ -53,17 +53,17 @@ function sendIfExpected(thread: GoogleAppsScript.Gmail.GmailThread) {
       }
     ],
   };
-  let payload = JSON.stringify(jsonPayload);
-  let options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
+  const payload = JSON.stringify(jsonPayload);
+  const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
     "method": "post",
     "contentType": "application/json",
     "payload": payload,
     "muteHttpExceptions": true
   };
 
-  let response = UrlFetchApp.fetch(Events.webhookURL(event), options);
-  let responseCode = response.getResponseCode();
-  let responseBody = response.getContentText();
+  const response = UrlFetchApp.fetch(Events.webhookURL(event), options);
+  const responseCode = response.getResponseCode();
+  const responseBody = response.getContentText();
 
   if (responseCode != 200) {
     console.log(Utilities.formatString("Request failed. Expected 200, got %d: %s", responseCode, responseBody));


### PR DESCRIPTION
fix #6 

## サマリ

- `let` を `const` に置き換えました．(全部置き換えたあとにエラーを示すもののみ元に戻しました)
- `var` の部分に関しても可能なものは `let` や `const` に置き換えました

## 確認項目

- [x] 私のSlackチームでテストして無事動くことを確認しました
- [x] VisualStudio Codeでエラーが表示されないことを確認しました
